### PR TITLE
Update signalr-quickstart-dotnet-core.md

### DIFF
--- a/articles/azure-signalr/signalr-quickstart-dotnet-core.md
+++ b/articles/azure-signalr/signalr-quickstart-dotnet-core.md
@@ -73,7 +73,7 @@ In this section, you will add the [Secret Manager tool](https://docs.microsoft.c
 
 1. Add a reference to the `Microsoft.Azure.SignalR` NuGet package by executing the following command:
 
-        dotnet add package Microsoft.Azure.SignalR -v 1.0.0-*
+        dotnet add package Microsoft.Azure.SignalR -v 1.0.*
 
 2. Execute the following command to restore packages for your project.
 
@@ -87,6 +87,12 @@ In this section, you will add the [Secret Manager tool](https://docs.microsoft.c
 
     ```
     dotnet user-secrets set Azure:SignalR:ConnectionString "Endpoint=<Your endpoint>;AccessKey=<Your access key>;"    
+    ```
+
+    Note that the version part should be provided if the version of `Microsoft.Azure.SignalR` NuGet package is lower than 1.0.6.
+
+    ```
+    dotnet user-secrets set Azure:SignalR:ConnectionString "Endpoint=<Your endpoint>;AccessKey=<Your access key>;Version=<Your version>;"
     ```
 
     Secret Manager will only be used for testing the web app while it is hosted locally. In a later tutorial, you will deploy the chat web app to Azure. Once the web app is deployed to Azure, you will use an application setting instead of storing the connection string with Secret Manager.


### PR DESCRIPTION
1. if the azure signalr package's version lower than 1.0.6, the version part should be provided in connection string
2. update the default version to the current latest (1.0.6)